### PR TITLE
Enable excerpts in graymatter

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -48,6 +48,11 @@ module.exports = function (config) {
     config.addTransform(transformName, transforms[transformName]);
   });
 
+	config.setFrontMatterParsingOptions({
+		excerpt: true,
+		excerpt_separator: "<!-- excerpt -->",
+	});
+
   // Markdown
   const md = markdownIt({
       html: true,

--- a/src/_includes/head/meta-info.njk
+++ b/src/_includes/head/meta-info.njk
@@ -25,9 +25,10 @@
   <meta property="og:image:alt" content="{{ coverAlt or '' }}">
   <meta property="twitter:image:alt" content="{{ coverAlt or '' }}">
 {% endif %}
-<meta property="description" content="{{ description or site.description }}">
-<meta property="og:description" content="{{ description or site.description }}">
-<meta property="twitter:description" content="{{ description or site.description }}">
+{% set desc = description or page.excerpt or site.description %}
+<meta property="description" content="{{ desc }}">
+<meta property="og:description" content="{{ desc }}">
+<meta property="twitter:description" content="{{ desc }}">
 
 {% if seo.image %}
   <meta property="og:image" content="{{ site.url }}{{ seo.image }}">


### PR DESCRIPTION
Configure excerpts so that I don't always have to write descriptions for my posts, I can just make the first couple sentences the description, which I much prefer for a blog like this.